### PR TITLE
Fix nix and qemu downloads.

### DIFF
--- a/docker/build-nixos/setup-image-user.sh
+++ b/docker/build-nixos/setup-image-user.sh
@@ -5,7 +5,7 @@ echo "building container as $USER"
 cd
 
 echo "setting up nix..."
-curl https://nixos.org/nix/install | sh -s --no-daemon
+curl -L https://nixos.org/nix/install | sh -s --no-daemon
 . /home/nixos/.nix-profile/etc/profile.d/nix.sh
 
 # .profile loading does not seem to work with alpine, so we have to compromise.

--- a/docker/docker-compose.emulation.yml
+++ b/docker/docker-compose.emulation.yml
@@ -12,8 +12,8 @@ services:
     build:
       context: setup-qemu
       args:
-        QEMU_PKG_URL: "https://kojipkgs.fedoraproject.org/packages/qemu/5.0.0/2.fc33/x86_64/qemu-user-static-5.0.0-2.fc33.x86_64.rpm"
-        QEMU_PKG_HASH: "23d937fba676db4c7546b6b30469f2a7d92d480cfcf4bcd3e7fc86587dec085f"
+        QEMU_PKG_URL: "https://download-ib01.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/q/qemu-user-static-5.0.0-2.fc33.x86_64.rpm"
+        QEMU_PKG_HASH: "f10098e4ece3f419c0e5883b7b9de01f7cfe376c272c576ef8553118d7ef9511"
         IMAGE_BASE: $IMAGE_BASE
     privileged: true
   # Main container, requires no elevated privileges to run. Builds NixOS.


### PR DESCRIPTION
The nix URL is returning HTTP 301.  We add the `-L` arg to make curl follow it.

Also, the qemu download URL is returning 503.  We update the URL to the one listed on the Fedora package page.

```
$ curl -I https://nixos.org/nix/install
HTTP/2 301 
content-length: 0
date: Fri, 19 Jun 2020 06:04:07 GMT
location: https://releases.nixos.org/nix/nix-2.3.6/install
server: Netlify
via: 1.1 7452590c60991e4e4499f2a0095052b8.cloudfront.net (CloudFront)
x-amz-cf-id: 89g-QDSN-Gqa0KjKycxvhvWW_klAodcqziFnB1CqdHMS_z2e6danjw==
x-amz-cf-pop: NRT51-C2
x-cache: Miss from cloudfront
age: 2422
x-nf-request-id: 3b573f7b-eeef-41a8-93c8-0f61a4b7d1cd-1399326

$ curl -I https://kojipkgs.fedoraproject.org/packages/qemu/5.0.0/2.fc33/x86_64/qemu-user-static-5.0.0-2.fc33.x86_64.rpm
HTTP/1.1 503 Service Temporarily Unavailable
Date: Fri, 19 Jun 2020 06:45:39 GMT
Server: Apache
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
content-length: 3476
cache-control: no-cache
pragma: no-cache
content-type: text/html; charset=UTF-8
AppTime: D=360
X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
X-Fedora-RequestID: XuxfE4uqacSqzgYDzUzqeQAABc8
Connection: close
```