### PR TITLE
Add xz to get past the error

### DIFF
--- a/docker/build-nixos/Dockerfile
+++ b/docker/build-nixos/Dockerfile
@@ -7,7 +7,7 @@ ARG NIXPKGS_BRANCH
 ARG APPLY_CPTOFS_PATCH
 ARG DISABLE_ZFS_IN_INSTALLER
 
-RUN apk add curl git sudo patch
+RUN apk add curl git sudo patch xz
 RUN adduser -D nixos
 RUN mkdir -m 0755 /nix
 RUN chown nixos /nix


### PR DESCRIPTION
Followed the Readme on macos at the time of writing. Kept getting an error about xz not being available. This change helped it continue the install process. 

I'm a nixos newbie, so disregard if I'm off here.