### PR TITLE
Added .gitattributes EOL=LF, fixing errors when building on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This fixes the following error occuring when ./run.sh is used after cloning on a Windows host:
```bash
 => CACHED [setup-qemu 4/5] RUN apk add dpkg curl
 => ERROR [setup-qemu 5/5] RUN sh /root/setup-image.sh
 ------
 > [setup-qemu 5/5] RUN sh /root/setup-image.sh:
 0.313 /root/setup-image.sh: set: line 2: illegal option -
 failed to solve: process "/bin/sh -c sh /root/setup-image.sh" did not complete successfully: exit code: 2
```